### PR TITLE
fix: change nonce type from u64 to u32

### DIFF
--- a/node/src/benchmarking.rs
+++ b/node/src/benchmarking.rs
@@ -121,7 +121,7 @@ pub fn create_benchmark_extrinsic(
 			period,
 			best_block.saturated_into(),
 		)),
-		frame_system::CheckNonce::<runtime::Runtime>::from(nonce as u64),
+		frame_system::CheckNonce::<runtime::Runtime>::from(nonce),
 		frame_system::CheckWeight::<runtime::Runtime>::new(),
 		pallet_transaction_payment::ChargeTransactionPayment::<runtime::Runtime>::from(0),
 	);

--- a/pallets/subspace/src/mock.rs
+++ b/pallets/subspace/src/mock.rs
@@ -81,7 +81,7 @@ impl system::Config for Test {
 	type DbWeight = ();
 	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
-    type Nonce = u64;
+    type Nonce = u32;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type AccountId = U256;

--- a/pallets/subspace/tests/test_mock.rs
+++ b/pallets/subspace/tests/test_mock.rs
@@ -85,7 +85,7 @@ impl system::Config for Test {
 	type BlockLength = ();
 	type AccountId = U256;
 	type RuntimeCall = RuntimeCall;
-	type Nonce = u64;
+	type Nonce = u32;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Lookup = IdentityLookup<Self::AccountId>;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -99,7 +99,7 @@ pub type Index = u64;
 // A hash of some data used by the chain.
 pub type Hash = sp_core::H256;
 
-pub type Nonce = u64;
+pub type Nonce = u32;
 
 // Opaque types. These are used by the CLI to instantiate machinery that don't need to know
 // the specifics of the runtime. They can then be made to be agnostic over specific formats
@@ -232,7 +232,7 @@ impl frame_system::Config for Runtime {
 	type OnSetCode = ();
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
 	/// The index type for storing how many extrinsics an account has signed.
-	type Nonce = u64;
+	type Nonce = u32;
 }
 
 impl pallet_insecure_randomness_collective_flip::Config for Runtime {}


### PR DESCRIPTION
from substrateinterface import SubstrateInterface, Keypair


substrate = SubstrateInterface(url="ws://127.0.0.1:9944")

result = substrate.query('System', 'Account', ['5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'])
print(result.value['data']['free']) # 635278638077956496

call = substrate.compose_call(
    call_module='Balances',
    call_function='transfer',
    call_params={
        'dest': '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
        'value': 1 * 10**9
    }
)

keypair = Keypair.create_from_uri('//Alice')
print(keypair)
extrinsic = substrate.create_signed_extrinsic(call=call, keypair=keypair)

receipt = substrate.submit_extrinsic(extrinsic, wait_for_inclusion=True)

print(f"Extrinsic '{receipt.extrinsic_hash}' sent and included in block '{receipt.block_hash}'")